### PR TITLE
[MNG-6829] Replace StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/plugin/changelog/ChangeLogReport.java
+++ b/src/main/java/org/apache/maven/plugin/changelog/ChangeLogReport.java
@@ -51,7 +51,6 @@ import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.WriterFactory;
 
 import java.io.BufferedOutputStream;
@@ -916,12 +915,12 @@ public class ChangeLogReport
 
             ScmProviderRepository providerRepo = repository.getProviderRepository();
 
-            if ( !StringUtils.isEmpty( username ) )
+            if ( !(username == null || username.isEmpty()) )
             {
                 providerRepo.setUser( username );
             }
 
-            if ( !StringUtils.isEmpty( password ) )
+            if ( !(password == null || password.isEmpty()) )
             {
                 providerRepo.setPassword( password );
             }
@@ -932,28 +931,28 @@ public class ChangeLogReport
 
                 loadInfosFromSettings( repo );
 
-                if ( !StringUtils.isEmpty( username ) )
+                if ( !(username == null || username.isEmpty()) )
                 {
                     repo.setUser( username );
                 }
 
-                if ( !StringUtils.isEmpty( password ) )
+                if ( !(password == null || password.isEmpty()) )
                 {
                     repo.setPassword( password );
                 }
 
-                if ( !StringUtils.isEmpty( privateKey ) )
+                if ( !(privateKey == null || privateKey.isEmpty()) )
                 {
                     repo.setPrivateKey( privateKey );
                 }
 
-                if ( !StringUtils.isEmpty( passphrase ) )
+                if ( !(passphrase == null || passphrase.isEmpty()) )
                 {
                     repo.setPassphrase( passphrase );
                 }
             }
 
-            if ( !StringUtils.isEmpty( tagBase ) && repository.getProvider().equals( "svn" ) )
+            if ( !(tagBase == null || tagBase.isEmpty()) && repository.getProvider().equals( "svn" ) )
             {
                 SvnScmProviderRepository svnRepo = (SvnScmProviderRepository) repository.getProviderRepository();
 
@@ -1050,18 +1049,18 @@ public class ChangeLogReport
         }
 
         String scmConnection = project.getScm().getConnection();
-        if ( StringUtils.isNotEmpty( scmConnection ) && "connection".equals( connectionType.toLowerCase() ) )
+        if ( (scmConnection != null && !scmConnection.isEmpty()) && "connection".equals( connectionType.toLowerCase() ) )
         {
             connection = scmConnection;
         }
 
         String scmDeveloper = project.getScm().getDeveloperConnection();
-        if ( StringUtils.isNotEmpty( scmDeveloper ) && "developerconnection".equals( connectionType.toLowerCase() ) )
+        if ( (scmDeveloper != null && !scmDeveloper.isEmpty()) && "developerconnection".equals( connectionType.toLowerCase() ) )
         {
             connection = scmDeveloper;
         }
 
-        if ( StringUtils.isEmpty( connection ) )
+        if ( connection == null || connection.isEmpty() )
         {
             throw new MavenReportException( "SCM Connection is not set." );
         }

--- a/src/main/java/org/apache/maven/plugin/changelog/ChangeLogReport.java
+++ b/src/main/java/org/apache/maven/plugin/changelog/ChangeLogReport.java
@@ -915,12 +915,12 @@ public class ChangeLogReport
 
             ScmProviderRepository providerRepo = repository.getProviderRepository();
 
-            if ( !(username == null || username.isEmpty()) )
+            if ( !( username == null || username.isEmpty() ) )
             {
                 providerRepo.setUser( username );
             }
 
-            if ( !(password == null || password.isEmpty()) )
+            if ( !( password == null || password.isEmpty() ) )
             {
                 providerRepo.setPassword( password );
             }
@@ -931,28 +931,28 @@ public class ChangeLogReport
 
                 loadInfosFromSettings( repo );
 
-                if ( !(username == null || username.isEmpty()) )
+                if ( !( username == null || username.isEmpty() ) )
                 {
                     repo.setUser( username );
                 }
 
-                if ( !(password == null || password.isEmpty()) )
+                if ( !( password == null || password.isEmpty() ) )
                 {
                     repo.setPassword( password );
                 }
 
-                if ( !(privateKey == null || privateKey.isEmpty()) )
+                if ( !( privateKey == null || privateKey.isEmpty() ) )
                 {
                     repo.setPrivateKey( privateKey );
                 }
 
-                if ( !(passphrase == null || passphrase.isEmpty()) )
+                if ( !( passphrase == null || passphrase.isEmpty() ) )
                 {
                     repo.setPassphrase( passphrase );
                 }
             }
 
-            if ( !(tagBase == null || tagBase.isEmpty()) && repository.getProvider().equals( "svn" ) )
+            if ( !( tagBase == null || tagBase.isEmpty() ) && repository.getProvider().equals( "svn" ) )
             {
                 SvnScmProviderRepository svnRepo = (SvnScmProviderRepository) repository.getProviderRepository();
 
@@ -1049,13 +1049,15 @@ public class ChangeLogReport
         }
 
         String scmConnection = project.getScm().getConnection();
-        if ( (scmConnection != null && !scmConnection.isEmpty()) && "connection".equals( connectionType.toLowerCase() ) )
+        if ( ( scmConnection != null && !scmConnection.isEmpty() )
+                && "connection".equals( connectionType.toLowerCase() ) )
         {
             connection = scmConnection;
         }
 
         String scmDeveloper = project.getScm().getDeveloperConnection();
-        if ( (scmDeveloper != null && !scmDeveloper.isEmpty()) && "developerconnection".equals( connectionType.toLowerCase() ) )
+        if ( ( scmDeveloper != null && !scmDeveloper.isEmpty() )
+                && "developerconnection".equals( connectionType.toLowerCase() ) )
         {
             connection = scmDeveloper;
         }

--- a/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/info/SvnInfoCommandExpanded.java
+++ b/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/info/SvnInfoCommandExpanded.java
@@ -35,7 +35,6 @@ import org.apache.maven.scm.provider.svn.SvnTagBranchUtils;
 import org.apache.maven.scm.provider.svn.command.SvnCommand;
 import org.apache.maven.scm.provider.svn.repository.SvnScmProviderRepository;
 import org.apache.maven.scm.provider.svn.svnexe.command.SvnCommandLineUtils;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -122,7 +121,7 @@ public class SvnInfoCommandExpanded
             cl.createArg().setValue( "--recursive" );
         }
 
-        if ( StringUtils.isNotEmpty( revision ) )
+        if ( revision != null && !revision.isEmpty() )
         {
             cl.createArg().setValue( "-r" );
             cl.createArg().setValue( revision );
@@ -160,7 +159,7 @@ public class SvnInfoCommandExpanded
             cl.createArg().setValue( "--recursive" );
         }
 
-        if ( StringUtils.isNotEmpty( revision ) )
+        if ( revision != null && !revision.isEmpty() )
         {
             cl.createArg().setValue( "-r" );
             cl.createArg().setValue( revision );


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu