### PR TITLE
Upgrade to the Doxia 2.1.0 / maven-reporting-impl 4.0.0 stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,12 +146,44 @@ under the License.
   <properties>
     <javaVersion>8</javaVersion>
     <maven-scm.version>2.2.1</maven-scm.version>
-    <doxiaVersion>1.11.1</doxiaVersion>
+    <doxiaVersion>2.1.0</doxiaVersion>
     <mavenVersion>3.9.16</mavenVersion>
+    <resolverVersion>1.9.27</resolverVersion>
     <!-- used in ITs -->
     <sitePluginVersion>${version.maven-site-plugin}</sitePluginVersion>
     <project.build.outputTimestamp>2026-05-19T18:54:53Z</project.build.outputTimestamp>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- keep the whole Doxia stack, mostly inherited from maven-reporting-impl, on the same version -->
+      <dependency>
+        <groupId>org.apache.maven.doxia</groupId>
+        <artifactId>doxia-core</artifactId>
+        <version>${doxiaVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.doxia</groupId>
+        <artifactId>doxia-module-apt</artifactId>
+        <version>${doxiaVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.doxia</groupId>
+        <artifactId>doxia-module-xdoc</artifactId>
+        <version>${doxiaVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.doxia</groupId>
+        <artifactId>doxia-site-model</artifactId>
+        <version>${doxiaVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.doxia</groupId>
+        <artifactId>doxia-integration-tools</artifactId>
+        <version>${doxiaVersion}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- maven -->
@@ -196,13 +228,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>
-      <version>3.1.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>4.0.0</version>
     </dependency>
 
     <!-- doxia -->
@@ -210,22 +236,12 @@ under the License.
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-sink-api</artifactId>
       <version>${doxiaVersion}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-site-renderer</artifactId>
       <version>${doxiaVersion}</version>
       <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-container-default</artifactId>
-        </exclusion>
         <exclusion>
           <!-- exclude to not add maven-artifact in compile scope -->
           <groupId>org.apache.maven</groupId>
@@ -294,6 +310,43 @@ under the License.
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${resolverVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- needed to let the report mojos resolve the site skin when executed as standalone goal in tests -->
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
+      <version>${resolverVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
+      <version>${resolverVersion}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -311,6 +364,9 @@ under the License.
                 <ignoredUnusedDeclaredDependency>org.apache.maven.scm:*</ignoredUnusedDeclaredDependency>
                 <!-- runtime dependencies -->
                 <ignoredUnusedDeclaredDependency>javax.xml.bind:jaxb-api</ignoredUnusedDeclaredDependency>
+                <!-- test runtime only: repository transport used to resolve the site skin -->
+                <ignoredUnusedDeclaredDependency>org.apache.maven.resolver:maven-resolver-connector-basic</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>org.apache.maven.resolver:maven-resolver-transport-http</ignoredUnusedDeclaredDependency>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>

--- a/src/main/java/org/apache/maven/plugins/changelog/ChangeLogReport.java
+++ b/src/main/java/org/apache/maven/plugins/changelog/ChangeLogReport.java
@@ -55,7 +55,6 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.changelog.scm.provider.svn.svnexe.command.info.SvnInfoCommandExpanded;
-import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.AbstractMavenReport;
 import org.apache.maven.reporting.MavenReportException;
 import org.apache.maven.scm.ChangeFile;
@@ -242,12 +241,6 @@ public class ChangeLogReport extends AbstractMavenReport {
      */
     @Parameter
     private String[] excludes;
-
-    /**
-     * The Maven Project Object
-     */
-    @Parameter(defaultValue = "${project}", readonly = true, required = true)
-    private MavenProject project;
 
     /**
      */
@@ -1559,13 +1552,6 @@ public class ChangeLogReport extends AbstractMavenReport {
         }
 
         return absPath + newTarget;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    protected MavenProject getProject() {
-        return project;
     }
 
     /**

--- a/src/test/java/org/apache/maven/plugins/changelog/AbstractChangeLogReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/changelog/AbstractChangeLogReportTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.changelog;
+
+import javax.inject.Inject;
+
+import java.io.File;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.internal.aether.DefaultRepositorySystemSessionFactory;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.reporting.AbstractMavenReport;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+
+import static org.apache.maven.api.plugin.testing.MojoExtension.getBasedir;
+import static org.apache.maven.api.plugin.testing.MojoExtension.setVariableValueToObject;
+
+/**
+ * Common test setup for the report mojos: since maven-reporting-impl 4.x, a standalone report execution
+ * renders a full site page, which requires a usable repository session to resolve the site skin.
+ */
+abstract class AbstractChangeLogReportTest {
+
+    @Inject
+    private MavenSession mavenSession;
+
+    @Inject
+    private DefaultRepositorySystemSessionFactory repoSessionFactory;
+
+    @Inject
+    private MojoExecution mojoExecution;
+
+    @BeforeEach
+    void setUpRepositorySession() {
+        // prepare realistic repository session
+        ArtifactRepository localRepo = Mockito.mock(ArtifactRepository.class);
+        Mockito.when(localRepo.getBasedir()).thenReturn(new File(getBasedir(), "target/local-repo").getAbsolutePath());
+
+        MavenExecutionRequest request = new DefaultMavenExecutionRequest();
+        request.setLocalRepository(localRepo);
+
+        DefaultRepositorySystemSession systemSession = repoSessionFactory.newRepositorySession(request);
+        Mockito.when(mavenSession.getRepositorySession()).thenReturn(systemSession);
+
+        Mockito.when(mojoExecution.getPlugin()).thenReturn(new Plugin());
+    }
+
+    /**
+     * Executes a report mojo as a standalone goal.
+     * <p>
+     * The site descriptor of this very plugin (<code>src/site/site.xml</code>, the default value of the
+     * <code>siteDirectory</code> parameter within the test harness) defines no skin, so the mojo is pointed at an
+     * empty directory to have the default site descriptor - and hence a resolvable skin - used instead.
+     */
+    protected void executeReport(AbstractMavenReport mojo) throws Exception {
+        setVariableValueToObject(mojo, "siteDirectory", new File(getBasedir(), "target/test-harness/site"));
+
+        mojo.execute();
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/changelog/ChangeLogReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/changelog/ChangeLogReportTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Edwin Punzalan
  */
 @MojoTest
-class ChangeLogReportTest {
+class ChangeLogReportTest extends AbstractChangeLogReportTest {
     private ScmManager scmManager = new ScmManagerStub();
 
     @Provides
@@ -60,7 +60,7 @@ class ChangeLogReportTest {
     void testNoSource(ChangeLogReport mojo) throws Exception {
         setVariableValueToObject(mojo, "manager", scmManager);
 
-        mojo.execute();
+        executeReport(mojo);
 
         File outputDir = getVariableValueFromObject(mojo, "outputDirectory");
 
@@ -225,7 +225,7 @@ class ChangeLogReportTest {
         // use current directory project as basedir
         setVariableValueToObject(mojo, "basedir", new File(getBasedir(), "src/main/java"));
 
-        mojo.execute();
+        executeReport(mojo);
 
         File outputXML = getVariableValueFromObject(mojo, "outputXML");
 

--- a/src/test/java/org/apache/maven/plugins/changelog/DeveloperActivityReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/changelog/DeveloperActivityReportTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Edwin Punzalan
  */
 @MojoTest
-class DeveloperActivityReportTest {
+class DeveloperActivityReportTest extends AbstractChangeLogReportTest {
 
     @Provides
     @SuppressWarnings("unused")
@@ -66,7 +66,7 @@ class DeveloperActivityReportTest {
     @Test
     @InjectMojo(goal = "dev-activity", pom = "src/test/plugin-configs/dev-activity/no-source-plugin-config.xml")
     void testNoSource(DeveloperActivityReport mojo) throws Exception {
-        mojo.execute();
+        executeReport(mojo);
 
         File outputDir = getVariableValueFromObject(mojo, "outputDirectory");
 
@@ -89,7 +89,7 @@ class DeveloperActivityReportTest {
         setVariableValueToObject(mojo, "basedir", new File(getBasedir(), "src/main/java"));
         setVariableValueToObject(mojo, "outputXML", outputXML);
 
-        mojo.execute();
+        executeReport(mojo);
 
         String encoding = getVariableValueFromObject(mojo, "outputEncoding");
 

--- a/src/test/java/org/apache/maven/plugins/changelog/FileActivityReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/changelog/FileActivityReportTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Edwin Punzalan
  */
 @MojoTest
-class FileActivityReportTest {
+class FileActivityReportTest extends AbstractChangeLogReportTest {
 
     @Provides
     @SuppressWarnings("unused")
@@ -49,7 +49,7 @@ class FileActivityReportTest {
     @InjectMojo(goal = "file-activity", pom = "src/test/plugin-configs/file-activity/no-source-plugin-config.xml")
     void testNoSource(FileActivityReport mojo) throws Exception {
 
-        mojo.execute();
+        executeReport(mojo);
 
         File outputDir = getVariableValueFromObject(mojo, "outputDirectory");
 
@@ -72,7 +72,7 @@ class FileActivityReportTest {
         setVariableValueToObject(mojo, "basedir", new File(getBasedir(), "src/main/java"));
         setVariableValueToObject(mojo, "outputXML", outputXML);
 
-        mojo.execute();
+        executeReport(mojo);
 
         String encoding = getVariableValueFromObject(mojo, "outputEncoding");
 

--- a/src/test/java/org/apache/maven/plugins/changelog/stubs/MavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/changelog/stubs/MavenProjectStub.java
@@ -19,11 +19,14 @@
 package org.apache.maven.plugins.changelog.stubs;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.api.plugin.testing.MojoExtension;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Scm;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.repository.RemoteRepository;
 
 /**
  * @author Edwin Punzalan
@@ -54,6 +57,15 @@ public class MavenProjectStub extends MavenProject {
      */
     public File getBasedir() {
         return new File(MojoExtension.getBasedir(), "target/test-harness/" + testCounter);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<RemoteRepository> getRemoteProjectRepositories() {
+        return Collections.singletonList(
+                new RemoteRepository.Builder("central", "default", "https://repo.maven.apache.org/maven2").build());
     }
 
     @Override


### PR DESCRIPTION
Supersedes #237, which bumped `doxiaVersion` alone and failed: Doxia 2.x no longer ships the legacy `org.codehaus.doxia.sink.Sink` still referenced by `maven-reporting-api` 3.x, so every report test died with `NoClassDefFoundError: org/codehaus/doxia/sink/Sink`. The Doxia bump cannot be done without moving `maven-reporting-impl` along with it.

### pom

* `doxiaVersion` 1.11.1 → 2.1.0
* `maven-reporting-impl` 3.1.0 → **4.0.0** — the version already used by maven-site-plugin 3.22.0 and the sibling reporting plugins
* the Doxia artifacts inherited from `maven-reporting-impl` (`doxia-core`, `doxia-module-apt`, `doxia-module-xdoc`, `doxia-site-model`, `doxia-integration-tools`) are pinned to `${doxiaVersion}` in `dependencyManagement`; without that, `doxia-site-model` 2.0.0 is mixed with `doxia-site-renderer` 2.1.0 and rendering fails with `NoSuchMethodError: SiteModel.getMermaid()`
* dropped the `plexus-container-default` exclusions, obsolete with Doxia 2.x (the `ensure-no-container-api` enforcer rule still passes)

### main code

`AbstractMavenReport` 4.x reads its own `protected project` field directly, so the shadowing copy in `ChangeLogReport` (and its `getProject()` override) is removed - otherwise the field stays null and site rendering fails with `project cannot be null`.

### tests

`AbstractMavenReport.execute()` is `final` since 4.0.0 and renders a full site page when the report runs as a standalone goal, which needs a usable repository session to resolve the site skin. The new `AbstractChangeLogReportTest` sets one up, following what maven-checkstyle-plugin already does, and `siteDirectory` is pointed at an empty directory so that the default site descriptor is used - this plugin's own `src/site/site.xml` declares no `<skin>`. Test-scoped `maven-resolver-connector-basic` and `maven-resolver-transport-http` are added so the skin can actually be downloaded.

### verification

`mvn -P run-its verify` is green: 23 unit tests, all 4 ITs, `dependency:analyze` and all enforcer rules including the Java 8 bytecode check. `mvn site` renders with Fluido 2.1.0, and the IT-generated `changelog.html`, `dev-activity.html` and `file-activity.html` have the expected content.

Note that the report unit tests now need network access to fetch the site skin into `target/local-repo`, same as the maven-checkstyle-plugin report tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)