### PR TITLE
Replace the maven-compat test dependency with what it was providing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,12 +207,6 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
@@ -225,6 +219,11 @@ under the License.
     </dependency>
 
     <!-- shared -->
+    <dependency>
+      <groupId>org.apache.maven.reporting</groupId>
+      <artifactId>maven-reporting-api</artifactId>
+      <version>4.0.0</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>


### PR DESCRIPTION
The plugin imports nothing from `maven-compat`, but removing it on its own breaks the build — and not in a way the tests notice.

`maven-reporting-api` was reaching the compile classpath *through* maven-compat, and `ChangeLogReport` extends `AbstractMavenReport`, which lives there. `mvn test` passes either way; `mvn verify` does not, because dependency analysis runs there:

```
[ERROR] Used undeclared dependencies found:
[ERROR]    org.apache.maven.reporting:maven-reporting-api:jar:4.0.0:compile
```

So this declares `maven-reporting-api` directly — which is what it should have been all along, since the code imports from it — and drops maven-compat.

**Verified:** `mvn verify` clean, tests 23/0 unchanged. I confirmed causation by running the same command on `master` (clean) and on the branch before this fix (fails), rather than assuming.

Worth recording for the wider maven-compat effort: this one *looked* like a pure pom deletion and was not. A plugin can import nothing from maven-compat and still depend on it for what it drags in transitively, and only `verify` reveals it.